### PR TITLE
Fix startScan function to work with custom IP Ranges

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ const generateIPRange = (
 };
 
 const startScan = (
-  config: Types.LSConfig,
+  config: Types.LSConfig | Types.LSConfigExtra,
   onProgress: (totalHosts: number, hostScanned: number) => void,
   onHostFound: (host: Types.LSSingleScanResult | null) => void,
   onFinish: (result: Types.LSSingleScanResult[]) => void
@@ -78,7 +78,7 @@ const startScan = (
     throw new Error('config.networkInfo param is required.');
   }
 
-  const ipRangeInfo = generateIPRange(config.networkInfo);
+  const ipRangeInfo = "ipRange" in config.networkInfo ? config.networkInfo : generateIPRange(config.networkInfo);
 
   const logging = config.logging || false;
   const ipRange = ipRangeInfo.ipRange;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -25,6 +25,14 @@ export interface LSConfig {
   logging?: boolean;
 }
 
+export interface LSConfigExtra {
+  networkInfo: LSNetworkInfoExtra;
+  ports?: number[];
+  timeout?: number;
+  threads?: number;
+  logging?: boolean;
+}
+
 export interface LSSingleScanConfig {
   ip: string;
   port: number;


### PR DESCRIPTION
The startScan function in index.ts has a bug- it automatically generates an IP range from config.networkInfo, regardless of whether it is of type LSNetworkInfo or LSNetworkInfoExtra. This fix will only generate the IP range automatically if config.networkInfo is of type LSNetworkInfo, allowing users of the library to perform scans with custom IP address ranges.